### PR TITLE
Switch to latest techdivision/import-attribute version 9.0.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Version 4.0.0
+
+## Bugfixes
+
+* None
+
+## Features
+
+* Switch to latest techdivision/import-attribute version 9.0.*
+* Add composite observers to minimize configuration complexity
+* Make Actions and ActionInterfaces deprecated, replace DI configuration with GenericAction + GenericIdentifierAction
+
 # Version 3.0.0
 
 ## Bugfixes

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "OSL-3.0",
     "require": {
         "php": ">=5.6.0",
-        "techdivision/import-attribute": "7.0.*"
+        "techdivision/import-attribute": "9.0.*"
     },
     "require-dev": {
         "doctrine/dbal": "2.5.*",

--- a/etc/techdivision-import.json
+++ b/etc/techdivision-import.json
@@ -93,11 +93,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_attribute_set.observer.clear.attribute.set",
-                    "import_attribute_set.observer.attribute.set",
-                    "import_attribute_set.observer.attribute.group",
-                    "import_attribute_set.observer.copy.parent.attribute.set",
-                    "import_attribute_set.observer.attribute.set.clean.up"
+                    "import_attribute_set.observer.composite.replace"
                   ]
                 }
               ]
@@ -140,10 +136,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_attribute_set.observer.attribute.set.update",
-                    "import_attribute_set.observer.attribute.group.update",
-                    "import_attribute_set.observer.copy.parent.attribute.set.update",
-                    "import_attribute_set.observer.attribute.set.clean.up"
+                    "import_attribute_set.observer.composite.add_update"
                   ]
                 }
               ]

--- a/src/Actions/EavAttributeGroupAction.php
+++ b/src/Actions/EavAttributeGroupAction.php
@@ -26,11 +26,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for EAV attribute groups.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2019 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-attribute-set
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-attribute-set
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 4.0.0 use \TechDivision\Import\Actions\GenericIdentifierAction instead
  */
 class EavAttributeGroupAction extends AbstractAction implements EavAttributeGroupActionInterface
 {

--- a/src/Actions/EavAttributeGroupActionInterface.php
+++ b/src/Actions/EavAttributeGroupActionInterface.php
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for action implementations that provides CRUD functionality for EAV attribute groups.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2019 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-attribute-set
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-attribute-set
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 4.0.0
  */
 interface EavAttributeGroupActionInterface extends ActionInterface
 {

--- a/src/Actions/EavAttributeSetAction.php
+++ b/src/Actions/EavAttributeSetAction.php
@@ -26,11 +26,12 @@ use TechDivision\Import\Actions\AbstractAction;
 /**
  * An action implementation that provides CRUD functionality for EAV attribute sets.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2019 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-attribute-set
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-attribute-set
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 4.0.0 use \TechDivision\Import\Actions\GenericIdentifierAction instead
  */
 class EavAttributeSetAction extends AbstractAction implements EavAttributeSetActionInterface
 {

--- a/src/Actions/EavAttributeSetActionInterface.php
+++ b/src/Actions/EavAttributeSetActionInterface.php
@@ -25,11 +25,12 @@ use TechDivision\Import\Actions\ActionInterface;
 /**
  * Interface for action implementations that provides CRUD functionality for EAV attribute sets.
  *
- * @author    Tim Wagner <t.wagner@techdivision.com>
- * @copyright 2019 TechDivision GmbH <info@techdivision.com>
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- * @link      https://github.com/techdivision/import-attribute-set
- * @link      http://www.techdivision.com
+ * @author     Tim Wagner <t.wagner@techdivision.com>
+ * @copyright  2019 TechDivision GmbH <info@techdivision.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link       https://github.com/techdivision/import-attribute-set
+ * @link       http://www.techdivision.com
+ * @deprecated Since version 4.0.0
  */
 interface EavAttributeSetActionInterface extends ActionInterface
 {

--- a/src/Services/AttributeSetBunchProcessor.php
+++ b/src/Services/AttributeSetBunchProcessor.php
@@ -20,13 +20,11 @@
 
 namespace TechDivision\Import\Attribute\Set\Services;
 
+use TechDivision\Import\Actions\ActionInterface;
 use TechDivision\Import\Connection\ConnectionInterface;
 use TechDivision\Import\Repositories\EavAttributeSetRepositoryInterface;
-use TechDivision\Import\Attribute\Set\Actions\EavAttributeSetActionInterface;
-use TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupActionInterface;
 use TechDivision\Import\Attribute\Set\Repositories\EntityAttributeRepositoryInterface;
 use TechDivision\Import\Attribute\Set\Repositories\EavAttributeGroupRepositoryInterface;
-use TechDivision\Import\Attribute\Actions\EntityAttributeActionInterface;
 
 /**
  * The attribute set bunch processor implementation.
@@ -71,21 +69,21 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * The attribute set action instance.
      *
-     * @var \TechDivision\Import\Attribute\Set\Actions\EavAttributeSetActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $eavAttributeSetAction;
 
     /**
      * The attribute group action instance.
      *
-     * @var \TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $eavAttributeGroupAction;
 
     /**
      * The entity attribute action instance.
      *
-     * @var \TechDivision\Import\Attribute\Actions\EntityAttributeActionInterface
+     * @var \TechDivision\Import\Actions\ActionInterface
      */
     protected $entityAttributeAction;
 
@@ -96,18 +94,18 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
      * @param \TechDivision\Import\Repositories\EavAttributeSetRepositoryInterface                 $eavAttributeSetRepository   The EAV attribute set repository instance
      * @param \TechDivision\Import\Attribute\Set\Repositories\EavAttributeGroupRepositoryInterface $eavAttributeGroupRepository The EAV attribute group repository instance
      * @param \TechDivision\Import\Attribute\Set\Repositories\EntityAttributeRepositoryInterface   $entityAttributeRepository   The EAV attribute option repository instance
-     * @param \TechDivision\Import\Attribute\Set\Actions\EavAttributeSetActionInterface            $eavAttributeSetAction       The EAV attribute set action instance
-     * @param \TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupActionInterface          $eavAttributeGroupAction     The EAV attribute gropu action instance
-     * @param \TechDivision\Import\Attribute\Actions\EntityAttributeActionInterface                $entityAttributeAction       The entity attribute action instance
+     * @param \TechDivision\Import\Actions\ActionInterface                                         $eavAttributeSetAction       The EAV attribute set action instance
+     * @param \TechDivision\Import\Actions\ActionInterface                                         $eavAttributeGroupAction     The EAV attribute gropu action instance
+     * @param \TechDivision\Import\Actions\ActionInterface                                         $entityAttributeAction       The entity attribute action instance
      */
     public function __construct(
         ConnectionInterface $connection,
         EavAttributeSetRepositoryInterface $eavAttributeSetRepository,
         EavAttributeGroupRepositoryInterface $eavAttributeGroupRepository,
         EntityAttributeRepositoryInterface $entityAttributeRepository,
-        EavAttributeSetActionInterface $eavAttributeSetAction,
-        EavAttributeGroupActionInterface $eavAttributeGroupAction,
-        EntityAttributeActionInterface $entityAttributeAction
+        ActionInterface $eavAttributeSetAction,
+        ActionInterface $eavAttributeGroupAction,
+        ActionInterface $entityAttributeAction
     ) {
         $this->setConnection($connection);
         $this->setEavAttributeSetRepository($eavAttributeSetRepository);
@@ -253,11 +251,11 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * Set's the EAV attribute set action instance.
      *
-     * @param \TechDivision\Import\Attribute\Set\Actions\EavAttributeSetActionInterface $eavAttributeSetAction The attribute set action instance
+     * @param \TechDivision\Import\Actions\ActionInterface $eavAttributeSetAction The attribute set action instance
      *
      * @return void
      */
-    public function setEavAttributeSetAction(EavAttributeSetActionInterface $eavAttributeSetAction)
+    public function setEavAttributeSetAction(ActionInterface $eavAttributeSetAction)
     {
         $this->eavAttributeSetAction = $eavAttributeSetAction;
     }
@@ -265,7 +263,7 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * Return's the attribute set action instance.
      *
-     * @return \TechDivision\Import\Attribute\Set\Actions\EavAttributeSetActionInterface The attribute set action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The attribute set action instance
      */
     public function getEavAttributeSetAction()
     {
@@ -275,11 +273,11 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * Set's the EAV attribute group action instance.
      *
-     * @param \TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupActionInterface $eavAttributeGroupAction The attribute gropu action instance
+     * @param \TechDivision\Import\Actions\ActionInterface $eavAttributeGroupAction The attribute gropu action instance
      *
      * @return void
      */
-    public function setEavAttributeGroupAction(EavAttributeGroupActionInterface $eavAttributeGroupAction)
+    public function setEavAttributeGroupAction(ActionInterface $eavAttributeGroupAction)
     {
         $this->eavAttributeGroupAction = $eavAttributeGroupAction;
     }
@@ -287,7 +285,7 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * Return's the attribute group action instance.
      *
-     * @return \TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupActionInterface The attribute group action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The attribute group action instance
      */
     public function getEavAttributeGroupAction()
     {
@@ -297,11 +295,11 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * Set's the entity attribute action instance.
      *
-     * @param \TechDivision\Import\Attribute\Actions\EntityAttributeActionInterface $entityAttributeAction The entity attribute action instance
+     * @param \TechDivision\Import\Actions\ActionInterface $entityAttributeAction The entity attribute action instance
      *
      * @return void
      */
-    public function setEntityAttributeAction(EntityAttributeActionInterface $entityAttributeAction)
+    public function setEntityAttributeAction(ActionInterface $entityAttributeAction)
     {
         $this->entityAttributeAction = $entityAttributeAction;
     }
@@ -309,7 +307,7 @@ class AttributeSetBunchProcessor implements AttributeSetBunchProcessorInterface
     /**
      * Return's the entity attribute action instance.
      *
-     * @return \TechDivision\Import\Attribute\Actions\EntityAttributeActionInterface The entity attribute action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The entity attribute action instance
      */
     public function getEntityAttributeAction()
     {

--- a/src/Services/AttributeSetBunchProcessorInterface.php
+++ b/src/Services/AttributeSetBunchProcessorInterface.php
@@ -56,16 +56,23 @@ interface AttributeSetBunchProcessorInterface extends AttributeSetProcessorInter
     /**
      * Return's the attribute set action instance.
      *
-     * @return \TechDivision\Import\Attribute\Set\Actions\EavAttributeSetActionInterface The attribute set action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The attribute set action instance
      */
     public function getEavAttributeSetAction();
 
     /**
      * Return's the attribute group action instance.
      *
-     * @return \TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupActionInterface The attribute group action instance
+     * @return \TechDivision\Import\Actions\ActionInterface The attribute group action instance
      */
     public function getEavAttributeGroupAction();
+
+    /**
+     * Return's the entity attribute action instance.
+     *
+     * @return \TechDivision\Import\Actions\ActionInterface The entity attribute action instance
+     */
+    public function getEntityAttributeAction();
 
     /**
      * Load's and return's the EAV attribute set with the passed entity type code and attribute set name.

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -41,12 +41,12 @@
             <argument type="service" id="import_attribute_set.repository.sql.statement"/>
         </service>
 
-        <service id="import_attribute_set.action.eav.attribute.set" class="TechDivision\Import\Attribute\Set\Actions\EavAttributeSetAction">
+        <service id="import_attribute_set.action.eav.attribute.set" class="TechDivision\Import\Actions\GenericIdentifierAction">
             <argument type="service" id="import_attribute_set.action.processor.eav.attribute.set.create"/>
             <argument type="service" id="import_attribute_set.action.processor.eav.attribute.set.update"/>
             <argument type="service" id="import_attribute_set.action.processor.eav.attribute.set.delete"/>
         </service>
-        <service id="import_attribute_set.action.eav.attribute.group" class="TechDivision\Import\Attribute\Set\Actions\EavAttributeGroupAction">
+        <service id="import_attribute_set.action.eav.attribute.group" class="TechDivision\Import\Actions\GenericIdentifierAction">
             <argument type="service" id="import_attribute_set.action.processor.eav.attribute.group.create"/>
             <argument type="service" id="import_attribute_set.action.processor.eav.attribute.group.update"/>
             <argument type="service" id="import_attribute_set.action.processor.eav.attribute.group.delete"/>
@@ -75,6 +75,45 @@
         </service>
         <service id="import_attribute_set.observer.copy.parent.attribute.set.update" class="TechDivision\Import\Attribute\Set\Observers\CopyParentAttributeSetUpdateObserver">
             <argument type="service" id="import_attribute_set.processor.attribute.set.bunch"/>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the attribute set replace operation.
+         |-->
+        <service id="import_attribute_set.observer.composite.replace" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.clear.attribute.set" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.attribute.set" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.attribute.group" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.copy.parent.attribute.set" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.attribute.set.clean.up" type="service"/>
+            </call>
+        </service>
+
+        <!--
+         | The DI configuration for the composite observers of the attribute set add-update operation.
+         |-->
+        <service id="import_attribute_set.observer.composite.add_update" class="TechDivision\Import\Observers\GenericCompositeObserver">
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.attribute.set.update" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.attribute.group.update" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.copy.parent.attribute.set.update" type="service"/>
+            </call>
+            <call method="addObserver">
+                <argument id="import_attribute_set.observer.attribute.set.clean.up" type="service"/>
+            </call>
         </service>
 
         <service id="import_attribute_set.processor.attribute.set.bunch" class="TechDivision\Import\Attribute\Set\Services\AttributeSetBunchProcessor">


### PR DESCRIPTION
Add composite observers to minimize configuration complexity
Make Actions and ActionInterfaces deprecated, replace DI configuration with GenericAction + GenericIdentifierAction